### PR TITLE
parcel error in exercise 2 was missing entry point

### DIFF
--- a/src/md/basic/foundations/hello-world.md
+++ b/src/md/basic/foundations/hello-world.md
@@ -66,19 +66,13 @@ cd my-node-app
 npm init --yes
 ```
 
-3. Install the npm package dependencies
+5. Add a start script to `package.json`
 
 ```bash
-npm install react react-dom parcel-bundler @architect/sandbox
+    "start": "arc sandbox"
 ```
 
-4. Add a start script to `package.json`
-
-```bash
-    "start": "parcel public/index.html & sandbox"
-```
-
-5. Start the server
+6. Start the server
 
 To start the server using npm, run the following command:
 
@@ -86,7 +80,7 @@ To start the server using npm, run the following command:
 npm start
 ```
 
-6. Preview in browser
+7. Preview in browser
 
 Visit [`http://localhost:3333`](http://localhost:3333) in your web browser to preview your Node application.
 


### PR DESCRIPTION
Changing Exercise 2 back to a more barebones example with `arc init` only, adding parcel here will cause an error because we have not instructed the user to create `public/index.html` as an entry point. The SPA example in the later section will cover this use case. 